### PR TITLE
Support boundingMapRect for MKOverlay classes.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "Source/MapKitTest/vendor/OCHamcrest"]
+	path = Source/MapKitTest/vendor/OCHamcrest
+	url = https://github.com/hamcrest/OCHamcrest.git
+[submodule "Source/MapKitTest/vendor/ocmock"]
+	path = Source/MapKitTest/vendor/ocmock
+	url = https://github.com/erikdoe/ocmock.git

--- a/Source/Framework/Classes/MKCircle.h
+++ b/Source/Framework/Classes/MKCircle.h
@@ -14,8 +14,9 @@
 
 @interface MKCircle : MKShape <MKOverlay> {
     @package
-    CLLocationCoordinate2D coordinate;
-    CLLocationDistance radius;
+    CLLocationCoordinate2D  coordinate;
+    CLLocationDistance      radius;
+    MKMapRect               boundingMapRect;
 }
 
 + (MKCircle *)circleWithCenterCoordinate:(CLLocationCoordinate2D)coord radius:(CLLocationDistance)radius;
@@ -23,5 +24,6 @@
 @property (nonatomic, readonly) CLLocationCoordinate2D coordinate;
 @property (nonatomic, readonly) CLLocationDistance radius;
 @property (nonatomic, readonly) MKCoordinateRegion region;
+@property (nonatomic, readonly) MKMapRect boundingMapRect; 
 
 @end

--- a/Source/Framework/Classes/MKCircle.m
+++ b/Source/Framework/Classes/MKCircle.m
@@ -18,6 +18,7 @@
 @implementation MKCircle
 
 @synthesize coordinate, radius;
+@synthesize boundingMapRect;
 
 + (MKCircle *)circleWithCenterCoordinate:(CLLocationCoordinate2D)aCoord radius:(CLLocationDistance)aRadius
 {

--- a/Source/Framework/Classes/MKCircle.m
+++ b/Source/Framework/Classes/MKCircle.m
@@ -44,6 +44,11 @@
     {
         coordinate = aCoord;
         radius = aRadius;
+        
+
+//TODO: set the boundingMapRect
+        
+        
     }
     return self;
 }

--- a/Source/Framework/Classes/MKGeometry+Private.h
+++ b/Source/Framework/Classes/MKGeometry+Private.h
@@ -1,0 +1,11 @@
+//
+//  MKGeometry+Private.h
+//  MapKit
+//
+//  Created by Markus on 17.10.12.
+//
+//
+
+#import "MKGeometry.h"
+
+

--- a/Source/Framework/Classes/MKGeometry+Private.m
+++ b/Source/Framework/Classes/MKGeometry+Private.m
@@ -72,3 +72,17 @@ CLLocationDistance MKMetersPerMapPointAtLatitude(CLLocationDegrees longitude)
 {
 	return 1.0/MKMapPointsPerMeterAtLatitude(longitude);
 }
+
+
+MKCoordinateRegion MKCoordinateRegionForMapRect(MKMapRect rect)
+{
+    CLLocationCoordinate2D center = MKCoordinateForMapPoint(MKMapPointMake(MKMapRectGetMidX(rect), MKMapRectGetMidY(rect)));
+    
+    
+    CLLocationCoordinate2D northWest = MKCoordinateForMapPoint(rect.origin);
+    CLLocationCoordinate2D southEast = MKCoordinateForMapPoint(MKMapPointMake(MKMapRectGetMaxX(rect), MKMapRectGetMaxY(rect)));
+    
+    
+    return MKCoordinateRegionMake(center, MKCoordinateSpanMake(northWest.latitude - southEast.latitude, southEast.longitude - northWest.longitude));
+    
+}

--- a/Source/Framework/Classes/MKGeometry+Private.m
+++ b/Source/Framework/Classes/MKGeometry+Private.m
@@ -9,7 +9,7 @@
 #import "MKGeometry+Private.h"
 
 // Number of pixels for zoom level 10
-#define MK_NUMBER_OF_PIXELS_AT_ZOOM_10 268435456
+#define MK_NUMBER_OF_PIXELS_AT_ZOOM_10 268435456.0f
 
 const MKMapSize MKMapSizeWorld = {MK_NUMBER_OF_PIXELS_AT_ZOOM_10,MK_NUMBER_OF_PIXELS_AT_ZOOM_10};
 
@@ -19,27 +19,28 @@ const MKMapRect MKMapRectWorld ={{0,0},{MK_NUMBER_OF_PIXELS_AT_ZOOM_10,MK_NUMBER
 
 // Functions taken from http://troybrant.net/blog/2010/01/mkmapview-and-zoom-levels-a-visual-guide/
 
-#define MERCATOR_OFFSET MKMapSizeWorld.width/2
+#define MERCATOR_OFFSET MKMapSizeWorld.width/2.0f
 #define MERCATOR_RADIUS MERCATOR_OFFSET/M_PI
 
 double longitudeToPixelSpaceX(double longitude)
 {
-    return round(MERCATOR_OFFSET + MERCATOR_RADIUS * longitude * M_PI / 180.0);
+//    return MERCATOR_OFFSET + MERCATOR_RADIUS * longitude * M_PI / 180.0f;
+    return MERCATOR_OFFSET * (1+ (longitude / 180.0f));
 }
 
 double latitudeToPixelSpaceY(double latitude)
 {
-    return round(MERCATOR_OFFSET - MERCATOR_RADIUS * logf((1 + sinf(latitude * M_PI / 180.0)) / (1 - sinf(latitude * M_PI / 180.0))) / 2.0);
+    return MERCATOR_OFFSET - MERCATOR_RADIUS * log((1.0f + sin(latitude * M_PI / 180.0f)) / (1.0f - sin(latitude * M_PI / 180.0f))) / 2.0f;
 }
 
 double pixelSpaceXToLongitude(double pixelX)
 {
-    return ((round(pixelX) - MERCATOR_OFFSET) / MERCATOR_RADIUS) * 180.0 / M_PI;
+    return ((round(pixelX) - MERCATOR_OFFSET) / MERCATOR_RADIUS) * 180.0f / M_PI;
 }
 
 double pixelSpaceYToLatitude(double pixelY)
 {
-    return (M_PI / 2.0 - 2.0 * atan(exp((round(pixelY) - MERCATOR_OFFSET) / MERCATOR_RADIUS))) * 180.0 / M_PI;
+    return (M_PI / 2.0f - 2.0f * atan(exp((round(pixelY) - MERCATOR_OFFSET) / MERCATOR_RADIUS))) * 180.0f / M_PI;
 }
 
 

--- a/Source/Framework/Classes/MKGeometry+Private.m
+++ b/Source/Framework/Classes/MKGeometry+Private.m
@@ -1,0 +1,57 @@
+//
+//  MKGeometry+Private.m
+//  MapKit
+//
+//  Created by Markus on 17.10.12.
+//
+//
+
+#import "MKGeometry+Private.h"
+
+// Number of pixels for zoom level 10
+#define MK_NUMBER_OF_PIXELS_AT_ZOOM_10 268435456
+
+const MKMapSize MKMapSizeWorld = {MK_NUMBER_OF_PIXELS_AT_ZOOM_10,MK_NUMBER_OF_PIXELS_AT_ZOOM_10};
+
+const MKMapRect MKMapRectWorld ={{0,0},{MK_NUMBER_OF_PIXELS_AT_ZOOM_10,MK_NUMBER_OF_PIXELS_AT_ZOOM_10}};
+
+
+
+// Functions taken from http://troybrant.net/blog/2010/01/mkmapview-and-zoom-levels-a-visual-guide/
+
+#define MERCATOR_OFFSET MKMapSizeWorld.width/2
+#define MERCATOR_RADIUS MERCATOR_OFFSET/M_PI
+
+double longitudeToPixelSpaceX(double longitude)
+{
+    return round(MERCATOR_OFFSET + MERCATOR_RADIUS * longitude * M_PI / 180.0);
+}
+
+double latitudeToPixelSpaceY(double latitude)
+{
+    return round(MERCATOR_OFFSET - MERCATOR_RADIUS * logf((1 + sinf(latitude * M_PI / 180.0)) / (1 - sinf(latitude * M_PI / 180.0))) / 2.0);
+}
+
+double pixelSpaceXToLongitude(double pixelX)
+{
+    return ((round(pixelX) - MERCATOR_OFFSET) / MERCATOR_RADIUS) * 180.0 / M_PI;
+}
+
+double pixelSpaceYToLatitude(double pixelY)
+{
+    return (M_PI / 2.0 - 2.0 * atan(exp((round(pixelY) - MERCATOR_OFFSET) / MERCATOR_RADIUS))) * 180.0 / M_PI;
+}
+
+
+
+
+extern  MKMapPoint MKMapPointForCoordinate(CLLocationCoordinate2D coordinate)
+{
+    return MKMapPointMake(longitudeToPixelSpaceX(coordinate.longitude), latitudeToPixelSpaceY(coordinate.latitude));
+    
+}
+
+extern  CLLocationCoordinate2D MKCoordinateForMapPoint(MKMapPoint mapPoint)
+{
+    return CLLocationCoordinate2DMake(pixelSpaceYToLatitude(mapPoint.y), pixelSpaceXToLongitude(mapPoint.x));
+}

--- a/Source/Framework/Classes/MKGeometry+Private.m
+++ b/Source/Framework/Classes/MKGeometry+Private.m
@@ -8,24 +8,27 @@
 
 #import "MKGeometry+Private.h"
 
-// Number of pixels for zoom level 10
-#define MK_NUMBER_OF_PIXELS_AT_ZOOM_10 268435456.0f
+// Number of pixels for zoom level 20
+#define MK_NUMBER_OF_PIXELS_AT_ZOOM_20 268435456.0f
 
-const MKMapSize MKMapSizeWorld = {MK_NUMBER_OF_PIXELS_AT_ZOOM_10,MK_NUMBER_OF_PIXELS_AT_ZOOM_10};
+const MKMapSize MKMapSizeWorld = {MK_NUMBER_OF_PIXELS_AT_ZOOM_20,MK_NUMBER_OF_PIXELS_AT_ZOOM_20};
 
-const MKMapRect MKMapRectWorld ={{0,0},{MK_NUMBER_OF_PIXELS_AT_ZOOM_10,MK_NUMBER_OF_PIXELS_AT_ZOOM_10}};
+const MKMapRect MKMapRectWorld ={{0,0},{MK_NUMBER_OF_PIXELS_AT_ZOOM_20,MK_NUMBER_OF_PIXELS_AT_ZOOM_20}};
 
 
 
 // Functions taken from http://troybrant.net/blog/2010/01/mkmapview-and-zoom-levels-a-visual-guide/
 
-#define MERCATOR_OFFSET MKMapSizeWorld.width/2.0f
-#define MERCATOR_RADIUS MERCATOR_OFFSET/M_PI
+#define MERCATOR_OFFSET (MKMapSizeWorld.width/2.0f)
+#define MERCATOR_RADIUS (MERCATOR_OFFSET/M_PI)
+#define MKPOINTS_PER_METER (6.74355336508965f)
+#define WGS_EARTH_RADIUS 6378137.0f
+
 
 double longitudeToPixelSpaceX(double longitude)
 {
 //    return MERCATOR_OFFSET + MERCATOR_RADIUS * longitude * M_PI / 180.0f;
-    return MERCATOR_OFFSET * (1+ (longitude / 180.0f));
+    return MERCATOR_OFFSET * (1.0f + (longitude / 180.0f));
 }
 
 double latitudeToPixelSpaceY(double latitude)
@@ -35,12 +38,12 @@ double latitudeToPixelSpaceY(double latitude)
 
 double pixelSpaceXToLongitude(double pixelX)
 {
-    return ((round(pixelX) - MERCATOR_OFFSET) / MERCATOR_RADIUS) * 180.0f / M_PI;
+    return (((pixelX/MERCATOR_OFFSET)-1.0f) * 180.0f);
 }
 
 double pixelSpaceYToLatitude(double pixelY)
 {
-    return (M_PI / 2.0f - 2.0f * atan(exp((round(pixelY) - MERCATOR_OFFSET) / MERCATOR_RADIUS))) * 180.0f / M_PI;
+    return (M_PI / 2.0f - 2.0f * atan(exp((pixelY - MERCATOR_OFFSET) / MERCATOR_RADIUS))) * 180.0f / M_PI;
 }
 
 
@@ -55,4 +58,17 @@ extern  MKMapPoint MKMapPointForCoordinate(CLLocationCoordinate2D coordinate)
 extern  CLLocationCoordinate2D MKCoordinateForMapPoint(MKMapPoint mapPoint)
 {
     return CLLocationCoordinate2DMake(pixelSpaceYToLatitude(mapPoint.y), pixelSpaceXToLongitude(mapPoint.x));
+}
+
+
+//FIXME: Conversion functions do not return the same values as iOS MapKit.
+
+double MKMapPointsPerMeterAtLatitude(CLLocationDegrees latitude)
+{
+	return (cos((latitude * M_PI/ 180.0f)) * MK_NUMBER_OF_PIXELS_AT_ZOOM_20)/(2.0f * M_PI * WGS_EARTH_RADIUS);
+}
+
+CLLocationDistance MKMetersPerMapPointAtLatitude(CLLocationDegrees longitude)
+{
+	return 1.0/MKMapPointsPerMeterAtLatitude(longitude);
 }

--- a/Source/Framework/Classes/MKGeometry.h
+++ b/Source/Framework/Classes/MKGeometry.h
@@ -158,9 +158,11 @@ extern void MKMapRectDivide(MKMapRect rect, MKMapRect *slice, MKMapRect *remaind
 extern BOOL MKMapRectContainsPoint(MKMapRect rect, MKMapPoint point);
 extern BOOL MKMapRectContainsRect(MKMapRect rect1, MKMapRect rect2);
 extern BOOL MKMapRectIntersectsRect(MKMapRect rect1, MKMapRect rect2);
+*/
 
 extern MKCoordinateRegion MKCoordinateRegionForMapRect(MKMapRect rect);
 
+/*
 extern BOOL MKMapRectSpans180thMeridian(MKMapRect rect);
 // For map rects that span the 180th meridian, this returns the portion of the rect
 // that lies outside of the world rect wrapped around to the other side of the

--- a/Source/Framework/Classes/MKGeometry.h
+++ b/Source/Framework/Classes/MKGeometry.h
@@ -72,11 +72,12 @@ extern  const MKMapRect MKMapRectWorld;
 extern  MKMapPoint MKMapPointForCoordinate(CLLocationCoordinate2D coordinate);
 extern  CLLocationCoordinate2D MKCoordinateForMapPoint(MKMapPoint mapPoint);
 
-/*
+
 // Conversion between distances and projected coordinates
 extern  CLLocationDistance MKMetersPerMapPointAtLatitude(CLLocationDegrees latitude);
 extern  double MKMapPointsPerMeterAtLatitude(CLLocationDegrees latitude);
 
+/*
 extern  CLLocationDistance MKMetersBetweenMapPoints(MKMapPoint a, MKMapPoint b);
 
 extern  const MKMapRect MKMapRectNull;*/

--- a/Source/Framework/Classes/MKGeometry.h
+++ b/Source/Framework/Classes/MKGeometry.h
@@ -60,7 +60,9 @@ typedef struct {
 // 0.5, 1 screen point = 2 MKMapPoints.
 typedef CGFloat MKZoomScale;
 
-// The map point for the coordinate (-90,180)
+ */
+
+
 extern const MKMapSize MKMapSizeWorld;
 // The rect that contains every map point in the world.
 extern  const MKMapRect MKMapRectWorld;
@@ -70,6 +72,7 @@ extern  const MKMapRect MKMapRectWorld;
 extern  MKMapPoint MKMapPointForCoordinate(CLLocationCoordinate2D coordinate);
 extern  CLLocationCoordinate2D MKCoordinateForMapPoint(MKMapPoint mapPoint);
 
+/*
 // Conversion between distances and projected coordinates
 extern  CLLocationDistance MKMetersPerMapPointAtLatitude(CLLocationDegrees latitude);
 extern  double MKMapPointsPerMeterAtLatitude(CLLocationDegrees latitude);

--- a/Source/Framework/Classes/MKMapView.h
+++ b/Source/Framework/Classes/MKMapView.h
@@ -59,6 +59,12 @@
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)coordinate animated:(BOOL)animated;
 - (void)setRegion:(MKCoordinateRegion)region animated:(BOOL)animated;
 
+// Access the visible region of the map in projected coordinates.
+@property (nonatomic) MKMapRect visibleMapRect;
+- (void)setVisibleMapRect:(MKMapRect)mapRect animated:(BOOL)animate;
+
+
+
 // Overlays
 - (void)addOverlay:(id < MKOverlay >)overlay;
 - (void)addOverlays:(NSArray *)overlays;

--- a/Source/Framework/Classes/MKMapView.m
+++ b/Source/Framework/Classes/MKMapView.m
@@ -179,7 +179,7 @@
     [self willChangeValueForKey:@"visibleMapRect"];
     visibleMapRect = mapRect;
     
-    [self setRegion:MKCoordinateRegionForMapRect(visibleMapRect) animated:animate];
+    [self setRegion:MKCoordinateRegionForMapRect(visibleMapRect) animated:NO];
     
     [self didChangeValueForKey:@"visibleMapRect"];
     

--- a/Source/Framework/Classes/MKMapView.m
+++ b/Source/Framework/Classes/MKMapView.m
@@ -24,7 +24,7 @@
 
 @implementation MKMapView
 
-@synthesize delegate, mapType, userLocation, showsUserLocation;
+@synthesize delegate, mapType, userLocation, showsUserLocation,visibleMapRect;
 
 
 - (id)initWithFrame:(NSRect)frame {
@@ -172,6 +172,21 @@
     [self didChangeValueForKey:@"centerCoordinate"];
     [self delegateRegionDidChangeAnimated:animated];
 }
+
+
+- (void)setVisibleMapRect:(MKMapRect)mapRect animated:(BOOL)animate
+{
+    [self willChangeValueForKey:@"visibleMapRect"];
+    visibleMapRect = mapRect;
+    
+    [self setRegion:MKCoordinateRegionForMapRect(visibleMapRect) animated:animate];
+    
+    [self didChangeValueForKey:@"visibleMapRect"];
+    
+}
+
+
+
 
 - (void)setShowsUserLocation:(BOOL)show
 {

--- a/Source/Framework/Classes/MKOverlay.h
+++ b/Source/Framework/Classes/MKOverlay.h
@@ -19,4 +19,6 @@
 // From MKAnnotation, for areas this should return the centroid of the area.
 @property (nonatomic, readonly) CLLocationCoordinate2D coordinate;
 
+@property (nonatomic, readonly) MKMapRect boundingMapRect;
+
 @end

--- a/Source/Framework/Classes/MKPolygon.m
+++ b/Source/Framework/Classes/MKPolygon.m
@@ -51,26 +51,25 @@
     if (self = [super init])
     {
         coordinates = malloc(sizeof(CLLocationCoordinate2D) * count);
-        CLLocationDegrees maxLatitude  = 0;
-        CLLocationDegrees minLatitude  = 0;
-        CLLocationDegrees maxLongitude = 0;
-        CLLocationDegrees minLongitude = 0;
+        
+        MKMapPoint minXY = MKMapPointForCoordinate(*coords);
+        MKMapPoint maxXY = MKMapPointForCoordinate(*coords);
         
         for (int i = 0; i < count; i++)
         {
             coordinates[i] = coords[i];
             
-            maxLatitude= MAX(maxLatitude,coords[i].latitude);
-            minLatitude= MIN(minLatitude,coords[i].latitude);
-            maxLongitude= MAX(maxLongitude,coords[i].longitude);
-            minLongitude= MIN(minLongitude,coords[i].longitude);
-        }
+            MKMapPoint mapPoint = MKMapPointForCoordinate(coords[i]);
+            
+            minXY.x= MIN(minXY.x,mapPoint.x);
+            minXY.y= MIN(minXY.y,mapPoint.y);
+            maxXY.x= MAX(maxXY.x,mapPoint.x);
+            maxXY.y= MAX(maxXY.y,mapPoint.y);
+
+            
+         }
         
-        MKMapPoint minXY= MKMapPointForCoordinate(CLLocationCoordinate2DMake(minLatitude, maxLongitude));
-        MKMapPoint maxXY= MKMapPointForCoordinate(CLLocationCoordinate2DMake(maxLatitude, minLongitude));
-        
-        
-        boundingMapRect = MKMapRectMake(maxXY.x, maxXY.y, minXY.x-maxXY.x, minXY.y-maxXY.y);
+        boundingMapRect = MKMapRectMake(minXY.x, minXY.y, (double)(maxXY.x-minXY.x), (double) maxXY.y-minXY.y);
         
         coordinateCount = count;
     }

--- a/Source/Framework/Classes/MKPolygon.m
+++ b/Source/Framework/Classes/MKPolygon.m
@@ -17,6 +17,9 @@
 
 @implementation MKPolygon
 
+
+
+@synthesize boundingMapRect;
 @synthesize interiorPolygons;
 
 + (MKPolygon *)polygonWithCoordinates:(CLLocationCoordinate2D *)coords count:(NSUInteger)count
@@ -48,10 +51,27 @@
     if (self = [super init])
     {
         coordinates = malloc(sizeof(CLLocationCoordinate2D) * count);
+        CLLocationDegrees maxLatitude  = 0;
+        CLLocationDegrees minLatitude  = 0;
+        CLLocationDegrees maxLongitude = 0;
+        CLLocationDegrees minLongitude = 0;
+        
         for (int i = 0; i < count; i++)
         {
             coordinates[i] = coords[i];
+            
+            maxLatitude= MAX(maxLatitude,coords[i].latitude);
+            minLatitude= MIN(minLatitude,coords[i].latitude);
+            maxLongitude= MAX(maxLongitude,coords[i].longitude);
+            minLongitude= MIN(minLongitude,coords[i].longitude);
         }
+        
+        MKMapPoint minXY= MKMapPointForCoordinate(CLLocationCoordinate2DMake(minLatitude, maxLongitude));
+        MKMapPoint maxXY= MKMapPointForCoordinate(CLLocationCoordinate2DMake(maxLatitude, minLongitude));
+        
+        
+        boundingMapRect = MKMapRectMake(maxXY.x, maxXY.y, minXY.x-maxXY.x, minXY.y-maxXY.y);
+        
         coordinateCount = count;
     }
     return self;
@@ -65,5 +85,10 @@
     }
     return self;
 }
+
+
+
+
+
 
 @end

--- a/Source/Framework/Classes/MKPolyline.m
+++ b/Source/Framework/Classes/MKPolyline.m
@@ -17,6 +17,9 @@
 
 @implementation MKPolyline
 
+
+@synthesize boundingMapRect;
+
 + (MKPolyline *)polylineWithCoordinates:(CLLocationCoordinate2D *)coords count:(NSUInteger)count
 {
     return [[[MKPolyline alloc] initWithCoordinates:coords count:count] autorelease];

--- a/Source/Framework/Classes/MKPolyline.m
+++ b/Source/Framework/Classes/MKPolyline.m
@@ -42,12 +42,26 @@
 {
     if (self = [super init])
     {
+        
+        MKMapPoint minXY = MKMapPointForCoordinate(*coords);
+        MKMapPoint maxXY = MKMapPointForCoordinate(*coords);
+   
         coordinates = malloc(sizeof(CLLocationCoordinate2D) * count);
         for (int i = 0; i < count; i++)
         {
             coordinates[i] = coords[i];
+            MKMapPoint mapPoint = MKMapPointForCoordinate(coords[i]);
+            
+            minXY.x= MIN(minXY.x,mapPoint.x);
+            minXY.y= MIN(minXY.y,mapPoint.y);
+            maxXY.x= MAX(maxXY.x,mapPoint.x);
+            maxXY.y= MAX(maxXY.y,mapPoint.y);
+
         }
         coordinateCount = count;
+  
+        boundingMapRect = MKMapRectMake(minXY.x, minXY.y, (double)(maxXY.x-minXY.x), (double) maxXY.y-minXY.y);
+    
     }
     return self;
 }

--- a/Source/MapKit.xcodeproj/project.pbxproj
+++ b/Source/MapKit.xcodeproj/project.pbxproj
@@ -113,6 +113,16 @@
 		5FE1308715E94B9600265D22 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FE1308615E94B9600265D22 /* CoreFoundation.framework */; };
 		5FE8314812A60AF600728ECE /* MapKitPluginLibrary.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5FE8314712A60AF600728ECE /* MapKitPluginLibrary.xib */; };
 		5FE8314C12A60BFF00728ECE /* MKMapViewAttributeInspector.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5FE8314B12A60BFF00728ECE /* MKMapViewAttributeInspector.xib */; };
+		9B298AD8162E145C002FBA29 /* MKGeometry+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B298AD7162E1459002FBA29 /* MKGeometry+Private.m */; };
+		9B298ADA162E1836002FBA29 /* MKGeometry+Private.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B298AD7162E1459002FBA29 /* MKGeometry+Private.m */; };
+		9B298AE3162F2B47002FBA29 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B298AE2162F2B47002FBA29 /* SenTestingKit.framework */; };
+		9B298AE5162F2B47002FBA29 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B298AE4162F2B47002FBA29 /* Cocoa.framework */; };
+		9B298AEF162F2B48002FBA29 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9B298AED162F2B48002FBA29 /* InfoPlist.strings */; };
+		9B298AF2162F2B48002FBA29 /* MapKitTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B298AF1162F2B48002FBA29 /* MapKitTest.m */; };
+		9B298B19162F309A002FBA29 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F6EF17D11F13F690077E84F /* MapKit.framework */; };
+		9B298B1A162F30BD002FBA29 /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B298B14162F3055002FBA29 /* OCMock.framework */; };
+		9B298B1B162F30C6002FBA29 /* OCHamcrest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B298B03162F303F002FBA29 /* OCHamcrest.framework */; };
+		9B298B46162F3283002FBA29 /* MKPolygonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B298B45162F3282002FBA29 /* MKPolygonTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -129,6 +139,55 @@
 			proxyType = 1;
 			remoteGlobalIDString = 5F6EF17C11F13F690077E84F;
 			remoteInfo = MapKit;
+		};
+		9B298B02162F303F002FBA29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B298AF8162F303E002FBA29 /* OCHamcrest.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 087601E213440806001B439B;
+			remoteInfo = OCHamcrest;
+		};
+		9B298B04162F303F002FBA29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B298AF8162F303E002FBA29 /* OCHamcrest.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 087601F713440807001B439B;
+			remoteInfo = OCHamcrestTests;
+		};
+		9B298B06162F303F002FBA29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B298AF8162F303E002FBA29 /* OCHamcrest.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 081BEE621345979F003F846A;
+			remoteInfo = libochamcrest;
+		};
+		9B298B08162F303F002FBA29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B298AF8162F303E002FBA29 /* OCHamcrest.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 081BEE6C1345979F003F846A;
+			remoteInfo = libochamcrestTests;
+		};
+		9B298B13162F3055002FBA29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B298B0A162F3055002FBA29 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 030EF0A814632FD000B04273;
+			remoteInfo = OCMock;
+		};
+		9B298B15162F3055002FBA29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B298B0A162F3055002FBA29 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 030EF0C014632FD000B04273;
+			remoteInfo = OCMockTests;
+		};
+		9B298B17162F3055002FBA29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B298B0A162F3055002FBA29 /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 030EF0DC14632FF700B04273;
+			remoteInfo = OCMockLib;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -268,6 +327,23 @@
 		5FE1308615E94B9600265D22 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		5FE8314712A60AF600728ECE /* MapKitPluginLibrary.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MapKitPluginLibrary.xib; sourceTree = "<group>"; };
 		5FE8314B12A60BFF00728ECE /* MKMapViewAttributeInspector.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MKMapViewAttributeInspector.xib; sourceTree = "<group>"; };
+		9B298AD6162E1458002FBA29 /* MKGeometry+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKGeometry+Private.h"; sourceTree = "<group>"; };
+		9B298AD7162E1459002FBA29 /* MKGeometry+Private.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKGeometry+Private.m"; sourceTree = "<group>"; };
+		9B298AE0162F2B47002FBA29 /* MapKitTest.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapKitTest.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B298AE2162F2B47002FBA29 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		9B298AE4162F2B47002FBA29 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		9B298AE7162F2B47002FBA29 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		9B298AE8162F2B47002FBA29 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		9B298AE9162F2B47002FBA29 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		9B298AEC162F2B48002FBA29 /* MapKitTest-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "MapKitTest-Info.plist"; sourceTree = "<group>"; };
+		9B298AEE162F2B48002FBA29 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		9B298AF0162F2B48002FBA29 /* MapKitTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapKitTest.h; sourceTree = "<group>"; };
+		9B298AF1162F2B48002FBA29 /* MapKitTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MapKitTest.m; sourceTree = "<group>"; };
+		9B298AF3162F2B48002FBA29 /* MapKitTest-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MapKitTest-Prefix.pch"; sourceTree = "<group>"; };
+		9B298AF8162F303E002FBA29 /* OCHamcrest.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OCHamcrest.xcodeproj; path = vendor/OCHamcrest/Source/OCHamcrest.xcodeproj; sourceTree = "<group>"; };
+		9B298B0A162F3055002FBA29 /* OCMock.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OCMock.xcodeproj; path = vendor/ocmock/Source/OCMock.xcodeproj; sourceTree = "<group>"; };
+		9B298B44162F3282002FBA29 /* MKPolygonTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKPolygonTest.h; sourceTree = "<group>"; };
+		9B298B45162F3282002FBA29 /* MKPolygonTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKPolygonTest.m; sourceTree = "<group>"; };
 		D2F7E79907B2D74100F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
@@ -303,6 +379,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9B298ADC162F2B47002FBA29 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9B298B19162F309A002FBA29 /* MapKit.framework in Frameworks */,
+				9B298AE3162F2B47002FBA29 /* SenTestingKit.framework in Frameworks */,
+				9B298AE5162F2B47002FBA29 /* Cocoa.framework in Frameworks */,
+				9B298B1A162F30BD002FBA29 /* OCMock.framework in Frameworks */,
+				9B298B1B162F30C6002FBA29 /* OCHamcrest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -312,6 +400,7 @@
 				5F6EF13511F13B0D0077E84F /* DemoApp.app */,
 				5F6EF17D11F13F690077E84F /* MapKit.framework */,
 				5FB7435711FE6E4A00AB2079 /* MapKit.ibplugin */,
+				9B298AE0162F2B47002FBA29 /* MapKitTest.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -324,6 +413,8 @@
 				5F6EF12311F13A920077E84F /* Framework */,
 				5FB7434111FE6D5C00AB2079 /* IBPlugin */,
 				0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */,
+				9B298AEA162F2B47002FBA29 /* MapKitTest */,
+				9B298AE1162F2B47002FBA29 /* Frameworks */,
 				034768DFFF38A50411DB9C8B /* Products */,
 			);
 			name = MapKit;
@@ -375,6 +466,8 @@
 				5FB7407611F8C81800AB2079 /* MKMapView+WebViewIntegration.m */,
 				5FBAF7C711F1486D004753A9 /* MKTypes.h */,
 				5FBAF7C811F1486D004753A9 /* MKGeometry.h */,
+				9B298AD6162E1458002FBA29 /* MKGeometry+Private.h */,
+				9B298AD7162E1459002FBA29 /* MKGeometry+Private.m */,
 				5FBAF7C911F1486D004753A9 /* MapKit.h */,
 				5FBAF7CA11F1486D004753A9 /* MKUserLocation.h */,
 				5FBAF7CB11F1486D004753A9 /* MKUserLocation.m */,
@@ -624,6 +717,79 @@
 			name = Views;
 			sourceTree = "<group>";
 		};
+		9B298AE1162F2B47002FBA29 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9B298AE2162F2B47002FBA29 /* SenTestingKit.framework */,
+				9B298AE4162F2B47002FBA29 /* Cocoa.framework */,
+				9B298AE6162F2B47002FBA29 /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9B298AE6162F2B47002FBA29 /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9B298AE7162F2B47002FBA29 /* AppKit.framework */,
+				9B298AE8162F2B47002FBA29 /* CoreData.framework */,
+				9B298AE9162F2B47002FBA29 /* Foundation.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		9B298AEA162F2B47002FBA29 /* MapKitTest */ = {
+			isa = PBXGroup;
+			children = (
+				9B298AF7162F3027002FBA29 /* Vendor */,
+				9B298AF0162F2B48002FBA29 /* MapKitTest.h */,
+				9B298AF1162F2B48002FBA29 /* MapKitTest.m */,
+				9B298AEB162F2B48002FBA29 /* Supporting Files */,
+				9B298B44162F3282002FBA29 /* MKPolygonTest.h */,
+				9B298B45162F3282002FBA29 /* MKPolygonTest.m */,
+			);
+			path = MapKitTest;
+			sourceTree = "<group>";
+		};
+		9B298AEB162F2B48002FBA29 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				9B298AEC162F2B48002FBA29 /* MapKitTest-Info.plist */,
+				9B298AED162F2B48002FBA29 /* InfoPlist.strings */,
+				9B298AF3162F2B48002FBA29 /* MapKitTest-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		9B298AF7162F3027002FBA29 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				9B298B0A162F3055002FBA29 /* OCMock.xcodeproj */,
+				9B298AF8162F303E002FBA29 /* OCHamcrest.xcodeproj */,
+			);
+			name = Vendor;
+			sourceTree = "<group>";
+		};
+		9B298AF9162F303E002FBA29 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9B298B03162F303F002FBA29 /* OCHamcrest.framework */,
+				9B298B05162F303F002FBA29 /* OCHamcrestTests.octest */,
+				9B298B07162F303F002FBA29 /* libochamcrest.a */,
+				9B298B09162F303F002FBA29 /* libochamcrestTests.octest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9B298B0B162F3055002FBA29 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9B298B14162F3055002FBA29 /* OCMock.framework */,
+				9B298B16162F3055002FBA29 /* OCMockTests.octest */,
+				9B298B18162F3055002FBA29 /* libOCMock.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -732,6 +898,24 @@
 			productReference = 5FB7435711FE6E4A00AB2079 /* MapKit.ibplugin */;
 			productType = "com.apple.product-type.bundle";
 		};
+		9B298ADF162F2B47002FBA29 /* MapKitTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9B298AF4162F2B48002FBA29 /* Build configuration list for PBXNativeTarget "MapKitTest" */;
+			buildPhases = (
+				9B298ADB162F2B47002FBA29 /* Sources */,
+				9B298ADC162F2B47002FBA29 /* Frameworks */,
+				9B298ADD162F2B47002FBA29 /* Resources */,
+				9B298ADE162F2B47002FBA29 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MapKitTest;
+			productName = MapKitTest;
+			productReference = 9B298AE0162F2B47002FBA29 /* MapKitTest.octest */;
+			productType = "com.apple.product-type.bundle";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -749,18 +933,82 @@
 				Japanese,
 				French,
 				German,
+				en,
 			);
 			mainGroup = 0867D691FE84028FC02AAC07 /* MapKit */;
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 9B298AF9162F303E002FBA29 /* Products */;
+					ProjectRef = 9B298AF8162F303E002FBA29 /* OCHamcrest.xcodeproj */;
+				},
+				{
+					ProductGroup = 9B298B0B162F3055002FBA29 /* Products */;
+					ProjectRef = 9B298B0A162F3055002FBA29 /* OCMock.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				5F6EF13411F13B0D0077E84F /* DemoApp */,
 				5F6EF17C11F13F690077E84F /* MapKitFramework */,
 				5FB7435611FE6E4A00AB2079 /* MapKit */,
+				9B298ADF162F2B47002FBA29 /* MapKitTest */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		9B298B03162F303F002FBA29 /* OCHamcrest.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OCHamcrest.framework;
+			remoteRef = 9B298B02162F303F002FBA29 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9B298B05162F303F002FBA29 /* OCHamcrestTests.octest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = OCHamcrestTests.octest;
+			remoteRef = 9B298B04162F303F002FBA29 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9B298B07162F303F002FBA29 /* libochamcrest.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libochamcrest.a;
+			remoteRef = 9B298B06162F303F002FBA29 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9B298B09162F303F002FBA29 /* libochamcrestTests.octest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = libochamcrestTests.octest;
+			remoteRef = 9B298B08162F303F002FBA29 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9B298B14162F3055002FBA29 /* OCMock.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OCMock.framework;
+			remoteRef = 9B298B13162F3055002FBA29 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9B298B16162F3055002FBA29 /* OCMockTests.octest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = OCMockTests.octest;
+			remoteRef = 9B298B15162F3055002FBA29 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		9B298B18162F3055002FBA29 /* libOCMock.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libOCMock.a;
+			remoteRef = 9B298B17162F3055002FBA29 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		5F6EF13111F13B0D0077E84F /* Resources */ = {
@@ -801,7 +1049,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9B298ADD162F2B47002FBA29 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9B298AEF162F2B48002FBA29 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		9B298ADE162F2B47002FBA29 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		5F6EF13211F13B0D0077E84F /* Sources */ = {
@@ -810,6 +1082,7 @@
 			files = (
 				5F6EF15011F13BCB0077E84F /* main.m in Sources */,
 				5F6EF16B11F13CB70077E84F /* DemoAppApplicationDelegate.m in Sources */,
+				9B298AD8162E145C002FBA29 /* MKGeometry+Private.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -817,6 +1090,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B298ADA162E1836002FBA29 /* MKGeometry+Private.m in Sources */,
 				5FBAF7A811F147EF004753A9 /* NSColor+Additions.m in Sources */,
 				5FBAF7BA11F1482E004753A9 /* NSObject+SBJSON.m in Sources */,
 				5FBAF7BC11F1482E004753A9 /* NSString+SBJSON.m in Sources */,
@@ -863,6 +1137,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9B298ADB162F2B47002FBA29 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9B298AF2162F2B48002FBA29 /* MapKitTest.m in Sources */,
+				9B298B46162F3283002FBA29 /* MKPolygonTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -877,6 +1160,17 @@
 			targetProxy = 5FB7436511FE6ED200AB2079 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		9B298AED162F2B48002FBA29 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				9B298AEE162F2B48002FBA29 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		1DEB91B208733DA50010E9CD /* Debug */ = {
@@ -1070,6 +1364,63 @@
 			};
 			name = Release;
 		};
+		9B298AF5162F2B48002FBA29 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = "\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"";
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "MapKitTest/MapKitTest-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				INFOPLIST_FILE = "MapKitTest/MapKitTest-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Debug;
+		};
+		9B298AF6162F2B48002FBA29 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = "\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"";
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "MapKitTest/MapKitTest-Prefix.pch";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				INFOPLIST_FILE = "MapKitTest/MapKitTest-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1105,6 +1456,15 @@
 			buildConfigurations = (
 				5FB7435B11FE6E4A00AB2079 /* Debug */,
 				5FB7435C11FE6E4A00AB2079 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9B298AF4162F2B48002FBA29 /* Build configuration list for PBXNativeTarget "MapKitTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9B298AF5162F2B48002FBA29 /* Debug */,
+				9B298AF6162F2B48002FBA29 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Source/MapKit.xcodeproj/project.pbxproj
+++ b/Source/MapKit.xcodeproj/project.pbxproj
@@ -123,6 +123,10 @@
 		9B298B1A162F30BD002FBA29 /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B298B14162F3055002FBA29 /* OCMock.framework */; };
 		9B298B1B162F30C6002FBA29 /* OCHamcrest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B298B03162F303F002FBA29 /* OCHamcrest.framework */; };
 		9B298B46162F3283002FBA29 /* MKPolygonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B298B45162F3282002FBA29 /* MKPolygonTest.m */; };
+		9B298BE71632A071002FBA29 /* MKCircleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B298BE61632A071002FBA29 /* MKCircleTest.m */; };
+		9B5FEFCF1632C27E009B0319 /* MKGeometryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B5FEFCE1632C27E009B0319 /* MKGeometryTest.m */; };
+		9B5FEFD81632C35D009B0319 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FBAF80711F14955004753A9 /* CoreLocation.framework */; };
+		9B5FEFDE1634A20A009B0319 /* MKPolyLineTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B5FEFDD1634A20A009B0319 /* MKPolyLineTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -344,6 +348,12 @@
 		9B298B0A162F3055002FBA29 /* OCMock.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OCMock.xcodeproj; path = vendor/ocmock/Source/OCMock.xcodeproj; sourceTree = "<group>"; };
 		9B298B44162F3282002FBA29 /* MKPolygonTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKPolygonTest.h; sourceTree = "<group>"; };
 		9B298B45162F3282002FBA29 /* MKPolygonTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKPolygonTest.m; sourceTree = "<group>"; };
+		9B298BE51632A070002FBA29 /* MKCircleTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKCircleTest.h; sourceTree = "<group>"; };
+		9B298BE61632A071002FBA29 /* MKCircleTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKCircleTest.m; sourceTree = "<group>"; };
+		9B5FEFCD1632C27E009B0319 /* MKGeometryTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKGeometryTest.h; sourceTree = "<group>"; };
+		9B5FEFCE1632C27E009B0319 /* MKGeometryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKGeometryTest.m; sourceTree = "<group>"; };
+		9B5FEFDC1634A20A009B0319 /* MKPolyLineTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKPolyLineTest.h; sourceTree = "<group>"; };
+		9B5FEFDD1634A20A009B0319 /* MKPolyLineTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKPolyLineTest.m; sourceTree = "<group>"; };
 		D2F7E79907B2D74100F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
@@ -383,6 +393,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B5FEFD81632C35D009B0319 /* CoreLocation.framework in Frameworks */,
 				9B298B19162F309A002FBA29 /* MapKit.framework in Frameworks */,
 				9B298AE3162F2B47002FBA29 /* SenTestingKit.framework in Frameworks */,
 				9B298AE5162F2B47002FBA29 /* Cocoa.framework in Frameworks */,
@@ -746,6 +757,12 @@
 				9B298AEB162F2B48002FBA29 /* Supporting Files */,
 				9B298B44162F3282002FBA29 /* MKPolygonTest.h */,
 				9B298B45162F3282002FBA29 /* MKPolygonTest.m */,
+				9B298BE51632A070002FBA29 /* MKCircleTest.h */,
+				9B298BE61632A071002FBA29 /* MKCircleTest.m */,
+				9B5FEFCD1632C27E009B0319 /* MKGeometryTest.h */,
+				9B5FEFCE1632C27E009B0319 /* MKGeometryTest.m */,
+				9B5FEFDC1634A20A009B0319 /* MKPolyLineTest.h */,
+				9B5FEFDD1634A20A009B0319 /* MKPolyLineTest.m */,
 			);
 			path = MapKitTest;
 			sourceTree = "<group>";
@@ -1143,6 +1160,9 @@
 			files = (
 				9B298AF2162F2B48002FBA29 /* MapKitTest.m in Sources */,
 				9B298B46162F3283002FBA29 /* MKPolygonTest.m in Sources */,
+				9B298BE71632A071002FBA29 /* MKCircleTest.m in Sources */,
+				9B5FEFCF1632C27E009B0319 /* MKGeometryTest.m in Sources */,
+				9B5FEFDE1634A20A009B0319 /* MKPolyLineTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/MapKitTest/MKCircleTest.h
+++ b/Source/MapKitTest/MKCircleTest.h
@@ -1,0 +1,13 @@
+//
+//  MKCircleTest.h
+//  MapKit
+//
+//  Created by Markus on 20.10.12.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface MKCircleTest : SenTestCase
+
+@end

--- a/Source/MapKitTest/MKCircleTest.m
+++ b/Source/MapKitTest/MKCircleTest.m
@@ -1,0 +1,53 @@
+//
+//  MKCircleTest.m
+//  MapKit
+//
+//  Created by Markus on 20.10.12.
+//
+//
+
+#import "MKCircleTest.h"
+#import <MapKit/MapKit.h>
+
+#import <OCMock/OCMock.h>
+
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
+
+@implementation MKCircleTest
+
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+    
+    [super tearDown];
+}
+
+#if 0  // TODO: conversion between MapPoints and meters is not correct on MacOSX
+- (void)testBoundingMapRect
+{
+    //Apple Headquarter
+    CLLocationCoordinate2D center= CLLocationCoordinate2DMake(37.3326, -122.0303);
+  
+    
+    MKCircle* circle = [MKCircle circleWithCenterCoordinate:center radius:1000.0];
+    
+    MKMapRect boundingMapRect = circle.boundingMapRect;
+    
+    assertThatDouble(43216891.34952898,equalToDouble(boundingMapRect.origin.x));
+    assertThatDouble(104163483.19862715899944305419921875,equalToDouble(boundingMapRect.origin.y));
+    assertThatDouble(16899.8214042689578491263091564178466796875,equalToDouble(boundingMapRect.size.width));
+    assertThatDouble(16899.8214042689578491263091564178466796875,equalToDouble(boundingMapRect.size.height));
+        
+}
+#endif
+
+@end

--- a/Source/MapKitTest/MKGeometryTest.h
+++ b/Source/MapKitTest/MKGeometryTest.h
@@ -1,0 +1,13 @@
+//
+//  MKGeometryTest.h
+//  MapKit
+//
+//  Created by Markus on 20.10.12.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface MKGeometryTest : SenTestCase
+
+@end

--- a/Source/MapKitTest/MKGeometryTest.m
+++ b/Source/MapKitTest/MKGeometryTest.m
@@ -111,6 +111,29 @@
 }
 
 
+- (void)testConversionMKMapRect2CoordinateRegion
+{
+    
+    
+    MKMapPoint points[] = {
+        MKMapPointMake(42739440.2760931551456451416015625   ,96012095.9123315513134002685546875),   // Portland
+        MKMapPointMake(117136036.84706987440586090087890625 ,169999587.945367515087127685546875),   // Rio
+        MKMapPointMake(164798670.6277262270450592041015625  ,111626999.71328115463256835937),   // Istanbul
+        MKMapPointMake(117863049.54040320217609405517578125 ,71362638.15177667140960693359375),   // Reykjavik
+    };
+
+    MKCoordinateRegion coordinateRegion =  MKCoordinateRegionForMapRect(MKMapRectMake(42739440, 96012095, 164798670-2739440, 111626999-96012095));
+    
+    assertThatDouble(coordinateRegion.center.latitude,closeTo(37.707426,0.000001));
+    assertThatDouble(coordinateRegion.center.longitude,closeTo(-14.012762,0.000001));
+    assertThatDouble(coordinateRegion.span.latitudeDelta,closeTo(16.543982,0.000001));
+    assertThatDouble(coordinateRegion.span.longitudeDelta,closeTo(217.338363,0.000001));
+ 
+    
+    
+}
+
+
 - (void)testConstants
 {
     

--- a/Source/MapKitTest/MKGeometryTest.m
+++ b/Source/MapKitTest/MKGeometryTest.m
@@ -1,0 +1,149 @@
+//
+//  MKGeometryTest.m
+//  MapKit
+//
+//  Created by Markus on 20.10.12.
+//
+//
+
+#import "MKGeometryTest.h"
+#import <MapKit/MapKit.h>
+
+#import <OCMock/OCMock.h>
+
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
+
+@implementation MKGeometryTest
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+    
+    [super tearDown];
+}
+
+
+- (void)testConversionCoordinate2MKPoint
+{
+
+    
+    CLLocationCoordinate2D portland     = CLLocationCoordinate2DMake(45.520000  ,-122.681944);
+    CLLocationCoordinate2D rioDeJaneiro = CLLocationCoordinate2DMake(-43.196389 ,-22.908333);
+    CLLocationCoordinate2D istanbul     = CLLocationCoordinate2DMake(28.976018  ,41.012240);
+    CLLocationCoordinate2D reykjavik    = CLLocationCoordinate2DMake(64.133333 , -21.933333);
+    
+    CLLocationCoordinate2D coordinates[] = {
+        portland,
+        rioDeJaneiro,
+        istanbul ,
+        reykjavik
+    };
+    
+    MKMapPoint points[] = {
+        MKMapPointMake(42739440.2760931551456451416015625   ,96012095.9123315513134002685546875),   // Portland
+
+        // FIXME: check only to 2 decimals of precision. Unclear why Rio values do not match.
+        
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+        MKMapPointMake(117136036.84706987440586090087890625 ,169999587.945367515087127685546875),   // Rio
+#endif
+ 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED
+        MKMapPointMake(117136036.84706985950469970703125 ,169999587.945367515087127685546875),   // Rio
+#endif
+        
+                       
+        MKMapPointMake(164798670.6277262270450592041015625  ,111626999.71328115463256835937),   // Istanbul
+        MKMapPointMake(117863049.54040320217609405517578125 ,71362638.15177667140960693359375),   // Reykjavik
+    };
+    
+    for (int i = 0; i < sizeof(coordinates)/sizeof(CLLocationCoordinate2D); i++)
+    {
+  
+        MKMapPoint mapPoint = MKMapPointForCoordinate(coordinates[i]);
+        assertThatDouble(mapPoint.x,equalToDouble(points[i].x));
+        assertThatDouble(mapPoint.y,equalToDouble(points[i].y));
+    }
+    
+
+}
+
+- (void)testConversionMKPoint2Coordinate
+{
+    
+    
+    CLLocationCoordinate2D portland     = CLLocationCoordinate2DMake(45.520000  ,-122.681944);
+    CLLocationCoordinate2D rioDeJaneiro = CLLocationCoordinate2DMake(-43.196389 ,-22.908333);
+    CLLocationCoordinate2D istanbul     = CLLocationCoordinate2DMake(28.976018  ,41.012240);
+    CLLocationCoordinate2D reykjavik    = CLLocationCoordinate2DMake(64.133333 , -21.933333);
+   
+    CLLocationCoordinate2D coordinates[] = {
+        portland,
+        rioDeJaneiro,
+        istanbul ,
+        reykjavik
+    };
+    
+    MKMapPoint points[] = {
+        MKMapPointMake(42739440.2760931551456451416015625   ,96012095.9123315513134002685546875),   // Portland
+        MKMapPointMake(117136036.84706987440586090087890625 ,169999587.945367515087127685546875),   // Rio
+        MKMapPointMake(164798670.6277262270450592041015625  ,111626999.71328115463256835937),   // Istanbul
+        MKMapPointMake(117863049.54040320217609405517578125 ,71362638.15177667140960693359375),   // Reykjavik
+    };
+    
+    for (int i = 0; i < sizeof(coordinates)/sizeof(CLLocationCoordinate2D); i++)
+    {
+        
+        CLLocationCoordinate2D coord = MKCoordinateForMapPoint(points[i]);
+        assertThatDouble(coord.latitude,closeTo(coordinates[i].latitude,0.000001));
+        assertThatDouble(coord.longitude,closeTo(coordinates[i].longitude,0.000001));
+    }
+    
+    
+}
+
+
+- (void)testConstants
+{
+    
+    MKMapSize mapWorld = MKMapSizeWorld;
+    assertThatDouble(268435456.0,equalToDouble(mapWorld.width));
+    assertThatDouble(268435456.0,equalToDouble(mapWorld.height));
+    
+    MKMapRect mapRect = MKMapRectWorld;
+    assertThatDouble(0,equalToDouble(mapRect.origin.x));
+    assertThatDouble(0,equalToDouble(mapRect.origin.y));
+    assertThatDouble(268435456.0,equalToDouble(mapRect.size.height));
+    assertThatDouble(268435456.0,equalToDouble(mapRect.size.width));
+
+}
+
+
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED  // TODO: conversion between MapPoints and meters is not correct on MacOSX
+- (void)testConversionBetweenMKPoint2Meter
+{
+    double pointsPerMeter = MKMapPointsPerMeterAtLatitude(37.3326);
+    
+    assertThatDouble(8.449910702134479,equalToDouble(pointsPerMeter));
+
+    
+    pointsPerMeter = MKMapPointsPerMeterAtLatitude(0);
+    assertThatDouble(6.74355336508965,equalToDouble(pointsPerMeter));
+    
+    double meterPerPoints = MKMetersPerMapPointAtLatitude(0);
+    assertThatDouble(0.1482897733377254445574777719230041839182376861572265625,equalToDouble(meterPerPoints));
+
+    
+}
+#endif
+
+@end

--- a/Source/MapKitTest/MKPolyLineTest.h
+++ b/Source/MapKitTest/MKPolyLineTest.h
@@ -1,0 +1,13 @@
+//
+//  MKPolyLineTest.h
+//  MapKit
+//
+//  Created by Markus on 21.10.12.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface MKPolyLineTest : SenTestCase
+
+@end

--- a/Source/MapKitTest/MKPolyLineTest.m
+++ b/Source/MapKitTest/MKPolyLineTest.m
@@ -1,0 +1,58 @@
+//
+//  MKPolyLineTest.m
+//  MapKit
+//
+//  Created by Markus on 21.10.12.
+//
+//
+
+#import "MKPolyLineTest.h"
+
+#import <MapKit/MapKit.h>
+
+#import <OCMock/OCMock.h>
+
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
+
+
+
+@implementation MKPolyLineTest
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+    
+    [super tearDown];
+}
+
+- (void)testPolygonWithCoordinates
+{
+    CLLocationCoordinate2D coordinates[] = {
+        {37.818844,-122.366278},
+        {37.819267,-122.365248},
+        {37.819861,-122.365640},
+        {37.819429,-122.366669},
+        {37.818844,-122.366278}
+    };
+    
+    
+    MKPolyline* polyline = [MKPolyline polylineWithCoordinates:coordinates count:5];
+    
+    MKMapRect boundingMapRect = polyline.boundingMapRect;
+    
+    assertThatDouble(42974526.354955375194549560546875,equalToDouble(boundingMapRect.origin.x));
+    assertThatDouble(103713496.57613144814968109130859375,equalToDouble(boundingMapRect.origin.y));
+    assertThatDouble(1059.574397161603,equalToDouble(boundingMapRect.size.width));
+    assertThatDouble(959.9748493880033,equalToDouble(boundingMapRect.size.height));
+    
+}
+@end
+

--- a/Source/MapKitTest/MKPolygonTest.h
+++ b/Source/MapKitTest/MKPolygonTest.h
@@ -1,0 +1,13 @@
+//
+//  MKPolygonTest.h
+//  MapKit
+//
+//  Created by Markus on 17.10.12.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface MKPolygonTest : SenTestCase
+
+@end

--- a/Source/MapKitTest/MKPolygonTest.m
+++ b/Source/MapKitTest/MKPolygonTest.m
@@ -35,19 +35,22 @@
 - (void)testPolygonWithCoordinates
 {
     CLLocationCoordinate2D coordinates[] = {
-        {-122.366278,37.818844},
-        {-122.365248,37.819267},
-        {-122.365640,37.819861},
-        {-122.366669,37.819429},
-        {-122.366278,37.818844}
+        {37.818844,-122.366278},
+        {37.819267,-122.365248},
+        {37.819861,-122.365640},
+        {37.819429,-122.366669},
+        {37.818844,-122.366278}
     };
     
-    MKPolygon* polygon = [MKPolygon polygonWithCoordinates:coordinates count:sizeof(coordinates)];
+    
+    MKPolygon* polygon = [MKPolygon polygonWithCoordinates:coordinates count:5];
     
     MKMapRect boundingMapRect = polygon.boundingMapRect;
     
-    assertThatDouble(1.5,equalToDouble(boundingMapRect.origin.x));
-    
-    
+    assertThatDouble(42974526.354955375194549560546875,equalToDouble(boundingMapRect.origin.x));
+    assertThatDouble(103713496.57613144814968109130859375,equalToDouble(boundingMapRect.origin.y));
+    assertThatDouble(1059.574397161603,equalToDouble(boundingMapRect.size.width));
+    assertThatDouble(959.9748493880033,equalToDouble(boundingMapRect.size.height));
+
 }
 @end

--- a/Source/MapKitTest/MKPolygonTest.m
+++ b/Source/MapKitTest/MKPolygonTest.m
@@ -1,0 +1,39 @@
+//
+//  MKPolygonTest.m
+//  MapKit
+//
+//  Created by Markus on 17.10.12.
+//
+//
+
+#import "MKPolygonTest.h"
+#import "MKPolygon.h"
+
+#import <OCMock/OCMock.h>
+
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
+
+
+
+@implementation MKPolygonTest
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+    
+    [super tearDown];
+}
+
+- (void)testPolygonWithCoordinates
+{
+    MKPolygon* polygon = [MKPolygon polygonWithCoordinates:<#(CLLocationCoordinate2D *)#> count:<#(NSUInteger)#>]
+}
+@end

--- a/Source/MapKitTest/MKPolygonTest.m
+++ b/Source/MapKitTest/MKPolygonTest.m
@@ -7,7 +7,7 @@
 //
 
 #import "MKPolygonTest.h"
-#import "MKPolygon.h"
+#import <MapKit/MapKit.h>
 
 #import <OCMock/OCMock.h>
 
@@ -34,6 +34,20 @@
 
 - (void)testPolygonWithCoordinates
 {
-    MKPolygon* polygon = [MKPolygon polygonWithCoordinates:<#(CLLocationCoordinate2D *)#> count:<#(NSUInteger)#>]
+    CLLocationCoordinate2D coordinates[] = {
+        {-122.366278,37.818844},
+        {-122.365248,37.819267},
+        {-122.365640,37.819861},
+        {-122.366669,37.819429},
+        {-122.366278,37.818844}
+    };
+    
+    MKPolygon* polygon = [MKPolygon polygonWithCoordinates:coordinates count:sizeof(coordinates)];
+    
+    MKMapRect boundingMapRect = polygon.boundingMapRect;
+    
+    assertThatDouble(1.5,equalToDouble(boundingMapRect.origin.x));
+    
+    
 }
 @end

--- a/Source/MapKitTest/MapKitTest-Info.plist
+++ b/Source/MapKitTest/MapKitTest-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>de.jemm.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Source/MapKitTest/MapKitTest-Prefix.pch
+++ b/Source/MapKitTest/MapKitTest-Prefix.pch
@@ -1,0 +1,7 @@
+//
+// Prefix header for all source files of the 'MapKitTest' target in the 'MapKitTest' project
+//
+
+#ifdef __OBJC__
+    #import <Cocoa/Cocoa.h>
+#endif

--- a/Source/MapKitTest/MapKitTest.h
+++ b/Source/MapKitTest/MapKitTest.h
@@ -1,0 +1,13 @@
+//
+//  MapKitTest.h
+//  MapKitTest
+//
+//  Created by Markus on 17.10.12.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface MapKitTest : SenTestCase
+
+@end

--- a/Source/MapKitTest/MapKitTest.m
+++ b/Source/MapKitTest/MapKitTest.m
@@ -1,0 +1,32 @@
+//
+//  MapKitTest.m
+//  MapKitTest
+//
+//  Created by Markus on 17.10.12.
+//
+//
+
+#import "MapKitTest.h"
+
+@implementation MapKitTest
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Set-up code here.
+}
+
+- (void)tearDown
+{
+    // Tear-down code here.
+    
+    [super tearDown];
+}
+
+- (void)testExample
+{
+   // STFail(@"Unit tests are not implemented yet in MapKitTest");
+}
+
+@end

--- a/Source/MapKitTest/en.lproj/InfoPlist.strings
+++ b/Source/MapKitTest/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+


### PR DESCRIPTION
Hello Rick,

I have added the property boundingMapRect to the MKOverlay classes.
To calculate the MKMapPoints, I have also updated the conversion functions between points and coordinates.

However, I was not able to calculate the boundingMapRect for MKCircle, since I could not convert the distance value to number of points. Do you have an idea how this shall be done?

Kindly take a look at the changes and merge them, if you think they are ok.

Thanks,
Markus
